### PR TITLE
feat: added filtering by label selector

### DIFF
--- a/src/commands/monitoring/metrics-annotations.ts
+++ b/src/commands/monitoring/metrics-annotations.ts
@@ -109,6 +109,10 @@ export default class MetricsAnnotations extends Command {
       delimiter: ',',
       multiple: true,
     }),
+    'label-selector': Flags.string({
+      char: 'l',
+      description: 'Label selector to filter workloads',
+    }),
     output: Flags.string({
       char: 'o',
       description: 'Output format',
@@ -137,7 +141,7 @@ export default class MetricsAnnotations extends Command {
 
     this.logToStderr(`Checking workloads in namespaces: ${flags.namespaces.join(', ')}`);
 
-    const workloadsResult = await retriever.getWorkloadMetricsInfoFromNamespaces(flags.namespaces);
+    const workloadsResult = await retriever.getWorkloadMetricsInfoFromNamespaces(flags.namespaces, flags['label-selector']);
 
     if (!workloadsResult.ok) {
       this.error(`Error: ${workloadsResult.error.message}`);

--- a/src/commands/route/validate-certs.ts
+++ b/src/commands/route/validate-certs.ts
@@ -137,6 +137,10 @@ export default class ValidateRouteCerts extends Command {
       delimiter: ',',
       multiple: true,
     }),
+    'label-selector': Flags.string({
+      char: 'l',
+      description: 'Label selector for filtering routes',
+    }),
     output: Flags.string({
       char: 'o',
       description: 'Output format',
@@ -165,7 +169,7 @@ export default class ValidateRouteCerts extends Command {
 
     this.logToStderr(`Checking routes in namespaces: ${flags.namespaces.join(', ')}`);
 
-    const routesResult = await retriever.getRoutesFromNamespaces(flags.namespaces);
+    const routesResult = await retriever.getRoutesFromNamespaces(flags.namespaces, flags['label-selector']);
 
     if (!routesResult.ok) {
       this.error(`Error: ${routesResult.error.message}`);

--- a/src/lib/k8s/workload-retriever.ts
+++ b/src/lib/k8s/workload-retriever.ts
@@ -5,13 +5,13 @@ import type { Result } from '../../types/shared.types.js';
 export class KubernetesWorkloadRetriever {
   public constructor(private readonly kubeClient: AppsV1Api) {}
 
-  public async getWorkloadMetricsInfoFromNamespaces(namespaces: string[]): Promise<Result<WorkloadMetricsInfo[], Error>> {
+  public async getWorkloadMetricsInfoFromNamespaces(namespaces: string[], labelSelector?: string): Promise<Result<WorkloadMetricsInfo[], Error>> {
     try {
       const allWorkloads: WorkloadMetricsInfo[] = [];
 
       for (const namespace of namespaces) {
-        const deployments = await this.getDeployments(namespace);
-        const statefulSets = await this.getStatefulSets(namespace);
+        const deployments = await this.getDeployments(namespace, labelSelector);
+        const statefulSets = await this.getStatefulSets(namespace, labelSelector);
 
         const deploymentWorkloads = deployments.map((deployment) => ({
           name: deployment.metadata?.name ?? '',
@@ -42,13 +42,13 @@ export class KubernetesWorkloadRetriever {
     }
   }
 
-  public async getDeployments(namespace: string): Promise<V1Deployment[]> {
-    const response = await this.kubeClient.listNamespacedDeployment({ namespace });
+  public async getDeployments(namespace: string, labelSelector?: string): Promise<V1Deployment[]> {
+    const response = await this.kubeClient.listNamespacedDeployment({ namespace, labelSelector });
     return response.items;
   }
 
-  public async getStatefulSets(namespace: string): Promise<V1StatefulSet[]> {
-    const response = await this.kubeClient.listNamespacedStatefulSet({ namespace });
+  public async getStatefulSets(namespace: string, labelSelector?: string): Promise<V1StatefulSet[]> {
+    const response = await this.kubeClient.listNamespacedStatefulSet({ namespace, labelSelector });
     return response.items;
   }
 

--- a/src/lib/openshift/route-retriever.ts
+++ b/src/lib/openshift/route-retriever.ts
@@ -14,12 +14,12 @@ export class OpenShiftRouteRetriever {
   /**
    * Retrieves routes from multiple namespaces
    */
-  public async getRoutesFromNamespaces(namespaces: readonly string[]): Promise<Result<RouteInfo[], Error>> {
+  public async getRoutesFromNamespaces(namespaces: readonly string[], labelSelector?: string): Promise<Result<RouteInfo[], Error>> {
     const allRoutes: RouteInfo[] = [];
     const errors: string[] = [];
 
     for (const namespace of namespaces) {
-      const result = await this.getRoutesFromNamespace(namespace);
+      const result = await this.getRoutesFromNamespace(namespace, labelSelector);
       if (result.ok) {
         allRoutes.push(...result.value);
       } else {
@@ -34,12 +34,13 @@ export class OpenShiftRouteRetriever {
     return { ok: true, value: allRoutes };
   }
 
-  private async getRoutesFromNamespace(namespace: string): Promise<Result<RouteInfo[], Error>> {
+  private async getRoutesFromNamespace(namespace: string, labelSelector?: string): Promise<Result<RouteInfo[], Error>> {
     try {
       const response = (await this.k8sApi.listNamespacedCustomObject({
         group: 'route.openshift.io',
         version: 'v1',
         namespace: namespace,
+        labelSelector: labelSelector,
         plural: 'routes',
       })) as components['schemas']['com.github.openshift.api.route.v1.RouteList'];
 


### PR DESCRIPTION
This pull request introduces a new `label-selector` flag to enhance filtering capabilities for workloads and routes in the `metrics-annotations` and `validate-certs` commands. It also updates the underlying retriever functions to support this flag and adds corresponding tests to ensure the functionality works as expected.

### Feature Enhancements:
* Added a `label-selector` flag to the `metrics-annotations` command to filter workloads based on labels. Updated the `retriever.getWorkloadMetricsInfoFromNamespaces` method to accept and utilize this flag. (`src/commands/monitoring/metrics-annotations.ts`, `src/lib/k8s/workload-retriever.ts`) [[1]](diffhunk://#diff-ab32c6be8734d9e196ca7104c595f0c5d22dc74a258316584fe2470fbbcb809eR112-R115) [[2]](diffhunk://#diff-ab32c6be8734d9e196ca7104c595f0c5d22dc74a258316584fe2470fbbcb809eL140-R144) [[3]](diffhunk://#diff-9e8c4c18875350884cc0009a27cb0d030556632461fd417dcb01116a037ff269L8-R14) [[4]](diffhunk://#diff-9e8c4c18875350884cc0009a27cb0d030556632461fd417dcb01116a037ff269L45-R51)

* Added a `label-selector` flag to the `validate-certs` command to filter routes based on labels. Updated the `retriever.getRoutesFromNamespaces` method to accept and utilize this flag. (`src/commands/route/validate-certs.ts`, `src/lib/openshift/route-retriever.ts`) [[1]](diffhunk://#diff-98db235d7a47174be2a9bcb7e0b6d2701c1058f2bfe7dea13e545b00b2df54c2R140-R143) [[2]](diffhunk://#diff-98db235d7a47174be2a9bcb7e0b6d2701c1058f2bfe7dea13e545b00b2df54c2L168-R172) [[3]](diffhunk://#diff-515f14648a99ac484651825e6331b3bd0e9383a3aa830ff9f74f063f84f737c8L17-R22) [[4]](diffhunk://#diff-515f14648a99ac484651825e6331b3bd0e9383a3aa830ff9f74f063f84f737c8L37-R43)

### Codebase Updates:
* Modified the `getDeployments`, `getStatefulSets`, and `getRoutesFromNamespace` methods to include an optional `labelSelector` parameter for filtering. (`src/lib/k8s/workload-retriever.ts`, `src/lib/openshift/route-retriever.ts`) [[1]](diffhunk://#diff-9e8c4c18875350884cc0009a27cb0d030556632461fd417dcb01116a037ff269L45-R51) [[2]](diffhunk://#diff-515f14648a99ac484651825e6331b3bd0e9383a3aa830ff9f74f063f84f737c8L37-R43)

### Testing:
* Added unit tests for the `metrics-annotations` command to verify the correct behavior of the `label-selector` flag, including cases where the flag is provided and omitted. (`tests/monitoring/metrics-annotations.spec.ts`) [[1]](diffhunk://#diff-2ae876aec5d3ea8939891578c6574efec45eabad30139694575cf92753c11764R1) [[2]](diffhunk://#diff-2ae876aec5d3ea8939891578c6574efec45eabad30139694575cf92753c11764R22-R23) [[3]](diffhunk://#diff-2ae876aec5d3ea8939891578c6574efec45eabad30139694575cf92753c11764R269-R320)

* Added unit tests for the `validate-certs` command to verify the correct behavior of the `label-selector` flag, including cases where the flag is provided and omitted. (`tests/route/validate-cert.spec.ts`) [[1]](diffhunk://#diff-a4f4d078c0abdb69c388ad7e9d8926490d29467eae4d5ebf2358d080a8f85f1eR1) [[2]](diffhunk://#diff-a4f4d078c0abdb69c388ad7e9d8926490d29467eae4d5ebf2358d080a8f85f1eR47) [[3]](diffhunk://#diff-a4f4d078c0abdb69c388ad7e9d8926490d29467eae4d5ebf2358d080a8f85f1eR317-R384)